### PR TITLE
COMPASS-873 - Update hadron-type-checker; BUMP 1.5.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Durran Jordan <durran@gmail.com>",
   "bugs": "https://github.com/mongodb-js/hadron-document/issues",
   "homepage": "https://github.com/mongodb-js/hadron-document",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "repository": {
     "type": "git",
     "url": "https://github.com/mongodb-js/hadron-document.git"

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
   ],
   "dependencies": {
     "debug": "^2.2.0",
-    "hadron-type-checker": "^1.1.0",
+    "hadron-type-checker": "^1.1.1",
     "lodash.foreach": "^4.3.0",
     "lodash.includes": "^4.1.3",
     "lodash.isarray": "^4.0.0",


### PR DESCRIPTION
Should fail until https://github.com/mongodb-js/hadron-type-checker/pull/11 is merged.