### PR TITLE
Do not allow subfields of _id to be edited

### DIFF
--- a/lib/element.js
+++ b/lib/element.js
@@ -348,12 +348,24 @@ class Element extends EventEmitter {
   }
 
   /**
+   * Determine if the key of the parent element is editable.
+   *
+   * @returns {Boolean} If the parent's key is editable.
+   */
+  isParentEditable() {
+    if (this.parent && 'currentKey' in this.parent) {
+      return this.parent.isKeyEditable();
+    }
+    return true;
+  }
+
+  /**
    * Determine if the key is editable.
    *
    * @returns {Boolean} If the key is editable.
    */
   isKeyEditable() {
-    return this.isAdded() || (this.currentKey !== ID);
+    return this.isParentEditable() && (this.isAdded() || (this.currentKey !== ID));
   }
 
   /**

--- a/lib/element.js
+++ b/lib/element.js
@@ -353,7 +353,7 @@ class Element extends EventEmitter {
    * @returns {Boolean} If the parent's key is editable.
    */
   isParentEditable() {
-    if (this.parent && 'currentKey' in this.parent) {
+    if (this.parent && !this.parent.isRoot()) {
       return this.parent.isKeyEditable();
     }
     return true;

--- a/test/element.test.js
+++ b/test/element.test.js
@@ -436,6 +436,41 @@ describe('Element', function() {
     });
   });
 
+  describe('#isEditable', function() {
+    context('when the key is _id and the value is a nested object', function() {
+      var subelement2 = new Element('subsubkey', 'test value');
+      var subelement = new Element('subkey', subelement2);
+      var element = new Element('_id', subelement);
+      subelement.parent = element;
+      subelement2.parent = subelement;
+      context('#isValueEditable', function() {
+        it('top level element returns false', function() {
+          expect(element.isValueEditable()).to.equal(false);
+        });
+        it('sub element returns false', function() {
+          expect(element.value.isValueEditable()).to.equal(false);
+        });
+        it('sub sub element returns false', function() {
+          expect(element.value.value.isValueEditable()).to.equal(false);
+        });
+      });
+      context('#isKeyEditable', function() {
+        it('top level element returns false', function() {
+          expect(element.isKeyEditable()).to.equal(false);
+          expect(element.isParentEditable()).to.equal(true);
+        });
+        it('sub element returns false', function() {
+          expect(element.value.isKeyEditable()).to.equal(false);
+          expect(element.value.isParentEditable()).to.equal(false);
+        });
+        it('sub sub element returns false', function() {
+          expect(element.value.value.isKeyEditable()).to.equal(false);
+          expect(element.value.value.isParentEditable()).to.equal(false);
+        });
+      });
+    });
+  });
+
   describe('#isValueEditable', function() {
     context('when the key is _id', function() {
       context('when the element is not added', function() {


### PR DESCRIPTION
Check that the parent of the element is editable before determining if the element is editable. Part of [COMPASS-310](https://jira.mongodb.org/browse/COMPASS-310).