### PR TITLE
Fix cancelling an empty document

### DIFF
--- a/lib/element.js
+++ b/lib/element.js
@@ -88,10 +88,9 @@ class Element extends EventEmitter {
       for (let element of this.elements) {
         element.cancel();
       }
-    } else {
-      if (this.isModified()) {
-        this.revert();
-      }
+    }
+    if (this.isModified()) {
+      this.revert();
     }
   }
 


### PR DESCRIPTION
There is a bug both in table and list view that occurs when reverting an empty document. If there are no elements, then the cancel doesn't get propagated. 