### PR TITLE
HadronElements of arrays set currentKey to index

### DIFF
--- a/lib/document.js
+++ b/lib/document.js
@@ -37,6 +37,7 @@ class Document extends EventEmitter {
    * Create the new document from the provided object.
    *
    * @param {Object} doc - The document.
+   * @param {boolean} cloned - If it is a cloned document.
    */
   constructor(doc, cloned) {
     super();
@@ -58,6 +59,8 @@ class Document extends EventEmitter {
   /**
    * Get an element by its key.
    *
+   * @param {String} key
+   *
    * @returns {Element} The element.
    */
   get(key) {
@@ -75,13 +78,13 @@ class Document extends EventEmitter {
     if (!path) {
       return undefined;
     }
-    let element = this.elements.get(path[0]);
+    let element = (this.currentType === 'Array') ? this.elements.at(path[0]) : this.elements.get(path[0]);
     let i = 1;
     while (i < path.length) {
       if (element === undefined) {
         return undefined;
       }
-      element = element.get(path[i]);
+      element = element.currentType === 'Array' ? element.at(path[i]) : element.get(path[i]);
       i++;
     }
     return element;

--- a/lib/document.js
+++ b/lib/document.js
@@ -101,6 +101,21 @@ class Document extends EventEmitter {
   }
 
   /**
+   * Get the _id value as a string. Required if _id is not always an ObjectId.
+   *
+   * @returns {String} The string id.
+   */
+  getStringId() {
+    const element = this.get(ID);
+    if (!element) {
+      return null;
+    } else if (element.currentType === 'Array' || element.currentType === 'Object') {
+      return JSON.stringify(element.generateObject());
+    }
+    return '' + element.value;
+  }
+
+  /**
    * Insert a placeholder element at the end of the document.
    *
    * @returns {Element} The placeholder element.

--- a/lib/element.js
+++ b/lib/element.js
@@ -150,6 +150,8 @@ class Element extends EventEmitter {
   /**
    * Get an element by its key.
    *
+   * @param {String} key - The key name.
+   *
    * @returns {Element} The element.
    */
   get(key) {
@@ -157,9 +159,22 @@ class Element extends EventEmitter {
   }
 
   /**
+   * Get an element by its index.
+   *
+   * @param {Number} i - The index.
+   *
+   * @returns {Element} The element.
+   */
+  at(i) {
+    return this.elements ? this.elements.at(i) : undefined;
+  }
+
+  /**
    * Go to the next edit.
    *
    * Will check if the value is either { or [ and take appropriate action.
+   *
+   *  @returns {Element} The next element.
    */
   next() {
     if (this.currentValue === CURLY) {
@@ -202,7 +217,9 @@ class Element extends EventEmitter {
   }
 
   /**
-   * Insert an element after the provided element.
+   * Insert an element after the provided element. If this element is an array,
+   * then ignore the key specified by the caller and use the correct index.
+   * Update the keys of the rest of the elements in the LinkedList.
    *
    * @param {Element} element - The element to insert after.
    * @param {String} key - The key.
@@ -211,7 +228,13 @@ class Element extends EventEmitter {
    * @returns {Element} The new element.
    */
   insertAfter(element, key, value) {
+    if (this.currentType === 'Array') {
+      key = element.currentKey + 1;
+    }
     var newElement = this.elements.insertAfter(element, key, value, true, this);
+    if (this.currentType === 'Array') {
+      this.elements.updateKeys(newElement, 1);
+    }
     this._bubbleUp(Events.Added);
     return newElement;
   }
@@ -219,12 +242,15 @@ class Element extends EventEmitter {
   /**
    * Add a new element to this element.
    *
-   * @param {String} key - The element key.
+   * @param {String | Number} key - The element key.
    * @param {Object} value - The value.
    *
    * @returns {Element} The new element.
    */
   insertEnd(key, value) {
+    if (this.currentType === 'Array') {
+      key = this.elements.lastElement ? this.elements.lastElement.currentKey + 1 : 0;
+    }
     var newElement = this.elements.insertEnd(key, value, true, this);
     this._bubbleUp(Events.Added);
     return newElement;
@@ -236,7 +262,11 @@ class Element extends EventEmitter {
    * @returns {Element} The placeholder element.
    */
   insertPlaceholder() {
-    return this.insertEnd('', '');
+    let key = '';
+    if (this.currentType === 'Array') {
+      key = this.elements.lastElement ? this.elements.lastElement.currentKey + 1 : 0;
+    }
+    return this.insertEnd(key, '');
   }
 
   /**
@@ -324,6 +354,8 @@ class Element extends EventEmitter {
 
   /**
    * Check for value equality.
+
+   * @returns {Boolean} If the value is equal.
    */
   _valuesEqual() {
     if (this.currentType === 'Date' && isString(this.currentValue)) {
@@ -456,6 +488,7 @@ class Element extends EventEmitter {
    */
   revert() {
     if (this.isAdded()) {
+      this.parent.elements.updateKeys(this, -1);
       this.parent.elements.remove(this);
       this.parent.emit(Events.Removed);
       this.parent = null;
@@ -483,6 +516,7 @@ class Element extends EventEmitter {
    * Fire and bubble up the event.
    *
    * @param {Event} evt - The event.
+   * @param {*} data - Optional.
    */
   _bubbleUp(evt, data) {
     this.emit(evt, data);
@@ -543,17 +577,24 @@ class Element extends EventEmitter {
    */
   _generateElements(object) {
     var elements = new LinkedList(); // eslint-disable-line no-use-before-define
+    let index = 0;
     for (let key of keys(object)) {
-      elements.insertEnd(this._key(key), object[key], this.added, this);
+      elements.insertEnd(this._key(key, index), object[key], this.added, this);
+      index ++;
     }
     return elements;
   }
 
   /**
    * Get the key for the element.
+   *
+   * @param {String} key
+   * @param {Number} index
+   *
+   * @returns {String|Number} The index if the type is an array, or the key.
    */
-  _key(key) {
-    return this.currentType === 'Array' ? '' : key;
+  _key(key, index) {
+    return this.currentType === 'Array' ? index : key;
   }
 
   /**
@@ -601,11 +642,11 @@ class LinkedList {
     var element = this.firstElement;
     for (var i = 0; i < index; i++) {
       if (!element) {
-        return null;
+        return undefined;
       }
       element = element.nextElement;
     }
-    return element;
+    return element === null ? undefined : element;
   }
 
   get(key) {
@@ -644,6 +685,19 @@ class LinkedList {
     this._map[newElement.key] = newElement;
     this.size += 1;
     return newElement;
+  }
+
+  /**
+   * Update the currentKey of each element if array elements.
+   *
+   * @param {Element} element - The element to insert after.
+   * @param {Number} add - 1 if adding a new element, -1 if removing.
+   */
+  updateKeys(element, add) {
+    while (element.nextElement) {
+      element.nextElement.currentKey += add;
+      element = element.nextElement;
+    }
   }
 
   /**

--- a/lib/element.js
+++ b/lib/element.js
@@ -639,6 +639,10 @@ class LinkedList {
    * @returns {Element} The matching element.
    */
   at(index) {
+    if (!Number.isInteger(index)) {
+      return undefined;
+    }
+
     var element = this.firstElement;
     for (var i = 0; i < index; i++) {
       if (!element) {

--- a/lib/element.js
+++ b/lib/element.js
@@ -341,15 +341,20 @@ class Element extends EventEmitter {
 
   /**
    * Determine if the element is edited - returns true if
-   * the key or value changed.
+   * the key or value changed. Does not count array values whose keys have
+   * changed as edited.
    *
    * @returns {Boolean} If the element is edited.
    */
   isEdited() {
-    return (this.key !== this.currentKey ||
-        !this._valuesEqual() ||
-        this.type !== this.currentType) &&
-        !this.isAdded();
+    let keyChanged = false;
+    if (!this.parent || this.parent.isRoot() || this.parent.currentType === 'Object') {
+      keyChanged = (this.key !== this.currentKey);
+    }
+    return (keyChanged ||
+      !this._valuesEqual() ||
+      this.type !== this.currentType) &&
+      !this.isAdded();
   }
 
   /**
@@ -478,10 +483,6 @@ class Element extends EventEmitter {
    * Flag the element for removal.
    */
   remove() {
-    if (!this.isRemoved() && !this.isAdded() &&
-        this.parent && this.parent.currentType === 'Array') {
-      this.parent.elements.updateKeys(this, -1);
-    }
     this.revert();
     this.removed = true;
     this._bubbleUp(Events.Removed);
@@ -499,9 +500,6 @@ class Element extends EventEmitter {
       this.parent.emit(Events.Removed);
       this.parent = null;
     } else {
-      if (this.isRemoved() && this.parent && this.parent.currentType === 'Array') {
-        this.parent.elements.updateKeys(this, 1);
-      }
       if (this.originalExpandableValue) {
         this.elements = this._generateElements(this.originalExpandableValue);
         this.currentValue = undefined;
@@ -709,8 +707,6 @@ class LinkedList {
   updateKeys(element, add) {
     while (element.nextElement) {
       element.nextElement.currentKey += add;
-      /* Don't want it to be modified when inserted before */
-      element.nextElement.key += add;
       element = element.nextElement;
     }
   }

--- a/lib/element.js
+++ b/lib/element.js
@@ -478,6 +478,10 @@ class Element extends EventEmitter {
    * Flag the element for removal.
    */
   remove() {
+    if (!this.isRemoved() && !this.isAdded() &&
+        this.parent && this.parent.currentType === 'Array') {
+      this.parent.elements.updateKeys(this, -1);
+    }
     this.revert();
     this.removed = true;
     this._bubbleUp(Events.Removed);
@@ -488,11 +492,16 @@ class Element extends EventEmitter {
    */
   revert() {
     if (this.isAdded()) {
-      this.parent.elements.updateKeys(this, -1);
+      if (this.parent && this.parent.currentType === 'Array') {
+        this.parent.elements.updateKeys(this, -1);
+      }
       this.parent.elements.remove(this);
       this.parent.emit(Events.Removed);
       this.parent = null;
     } else {
+      if (this.isRemoved() && this.parent && this.parent.currentType === 'Array') {
+        this.parent.elements.updateKeys(this, 1);
+      }
       if (this.originalExpandableValue) {
         this.elements = this._generateElements(this.originalExpandableValue);
         this.currentValue = undefined;
@@ -700,6 +709,8 @@ class LinkedList {
   updateKeys(element, add) {
     while (element.nextElement) {
       element.nextElement.currentKey += add;
+      /* Don't want it to be modified when inserted before */
+      element.nextElement.key += add;
       element = element.nextElement;
     }
   }

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "author": "Durran Jordan <durran@gmail.com>",
   "bugs": "https://github.com/mongodb-js/hadron-document/issues",
   "homepage": "https://github.com/mongodb-js/hadron-document",
-  "version": "3.1.1",
+  "version": "3.1.2",
   "repository": {
     "type": "git",
     "url": "https://github.com/mongodb-js/hadron-document.git"

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -54,6 +54,71 @@ describe('Document', function() {
     });
   });
 
+  describe('#getChild', function() {
+    const doc = new Document({
+      array: ['1', [ ['1', ['inner array']]]],
+      object: {a: {b: {c: {d: 'inner object'}}}},
+      mixed: {a: [ {b: [1, {c: 'inner mixed'}]}]}
+    });
+    context('when path is empty', () => {
+      it('returns undefined', () => {
+        expect(doc.getChild([])).to.equal(undefined);
+      });
+    });
+    context('when the path does not exist', () => {
+      it('returns undefined for top level', () => {
+        expect(doc.getChild(['not there'])).to.equal(undefined);
+      });
+      it('returns undefined for object', () => {
+        expect(doc.getChild(['object', 'not there'])).to.equal(undefined);
+      });
+      it('returns undefined for array', () => {
+        expect(doc.getChild(['array', 'not there'])).to.equal(undefined);
+      });
+      it('returns undefined for index too large', () => {
+        expect(doc.getChild(['array', 3])).to.equal(undefined);
+      });
+    });
+    context('when the path is too long', () => {
+      it('returns undefined', () => {
+        expect(doc.getChild(['mixed', 'a', 0, 'b', 1, 'c', 'not there'])).to.equal(undefined);
+      });
+    });
+    context('indexing only into arrays', () => {
+      it('returns the deepest element', () => {
+        const element = doc.getChild(['array', 1, 0, 1, 0]);
+        expect(element.value).to.equal('inner array');
+      });
+      it('returns a  middle element', () => {
+        const element = doc.getChild(['array', 1, 0]);
+        expect(element.currentType).to.equal('Array');
+        expect(element.generateObject()).to.deep.equal(['1', ['inner array']]);
+      });
+    });
+    context('indexing only into objects', () => {
+      it('returns the deepest element', () => {
+        const element = doc.getChild(['object', 'a', 'b', 'c', 'd']);
+        expect(element.value).to.equal('inner object');
+      });
+      it('returns a  middle element', () => {
+        const element = doc.getChild(['object', 'a', 'b']);
+        expect(element.currentType).to.equal('Object');
+        expect(element.generateObject()).to.deep.equal({c: {d: 'inner object'}});
+      });
+    });
+    context('indexing into mixed array and object', () => {
+      it('returns the deepest element', () => {
+        const element = doc.getChild(['mixed', 'a', 0, 'b', 1, 'c']);
+        expect(element.value).to.equal('inner mixed');
+      });
+      it('returns a  middle element', () => {
+        const element = doc.getChild(['mixed', 'a', 0, 'b']);
+        expect(element.currentType).to.equal('Array');
+        expect(element.generateObject()).to.deep.equal([1, {c: 'inner mixed'}]);
+      });
+    });
+  });
+
   describe('.insertEnd', function() {
     context('when the new element is a primitive value', function() {
       var doc = new Document({});

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -205,8 +205,8 @@ describe('Document', function() {
       });
 
       it('sets the element indexes', function() {
-        expect(doc.elements.at(0).elements.at(0).key).to.equal('');
-        expect(doc.elements.at(0).elements.at(1).key).to.equal('');
+        expect(doc.elements.at(0).elements.at(0).key).to.equal(0);
+        expect(doc.elements.at(0).elements.at(1).key).to.equal(1);
       });
 
       it('sets the element original values', function() {
@@ -289,7 +289,7 @@ describe('Document', function() {
         });
 
         it('sets the embedded element key', function() {
-          expect(doc.elements.at(0).elements.at(0).key).to.equal('');
+          expect(doc.elements.at(0).elements.at(0).key).to.equal(0);
         });
 
         it('sets the multi embedded element key', function() {
@@ -318,7 +318,7 @@ describe('Document', function() {
         });
 
         it('sets the multi embedded element key', function() {
-          expect(doc.elements.at(0).elements.at(0).elements.at(0).key).to.equal('');
+          expect(doc.elements.at(0).elements.at(0).elements.at(0).key).to.equal(0);
         });
 
         it('sets the lowest level embedded element key', function() {

--- a/test/document.test.js
+++ b/test/document.test.js
@@ -4,6 +4,7 @@ const chai = require('chai');
 const expect = chai.expect;
 const Document = require('../lib/document');
 const SharedExamples = require('./shared-examples');
+const ObjectId = require('bson').ObjectId;
 
 describe('Document', function() {
   describe('#get', function() {
@@ -223,6 +224,57 @@ describe('Document', function() {
 
       it('returns null', function() {
         expect(doc.getId()).to.deep.equal({ name: 'test' });
+      });
+    });
+  });
+
+  describe('#getStringId', function() {
+    context('when the document has no _id element', function() {
+      var doc = new Document({ name: 'test' });
+
+      it('returns null', function() {
+        expect(doc.getStringId()).to.equal(null);
+      });
+    });
+
+    context('when the _id is a string', function() {
+      var doc = new Document({ name: 'test', _id: 'testing' });
+
+      it('returns the _id', function() {
+        expect(doc.getStringId()).to.equal('testing');
+      });
+    });
+
+    context('when the _id is an objectId', function() {
+      const oid = new ObjectId();
+      var doc = new Document({ _id: oid });
+
+      it('returns null', function() {
+        expect(doc.getStringId()).to.equal(oid.toString());
+      });
+    });
+
+    context('when the _id is a number', function() {
+      var doc = new Document({ _id: 5 });
+
+      it('returns null', function() {
+        expect(doc.getStringId()).to.equal('5');
+      });
+    });
+
+    context('when the _id is an array', function() {
+      var doc = new Document({ _id: [1, 2, 3] });
+
+      it('returns null', function() {
+        expect(doc.getStringId()).to.equal('[1,2,3]');
+      });
+    });
+
+    context('when the _id is an object', function() {
+      var doc = new Document({ _id: {test: 'value'} });
+
+      it('returns null', function() {
+        expect(doc.getStringId()).to.equal('{"test":"value"}');
       });
     });
   });

--- a/test/element.test.js
+++ b/test/element.test.js
@@ -2041,7 +2041,33 @@ describe('Element', function() {
     });
 
     describe('#cancel', function() {
-
+      var doc = new Document({});
+      const items = [['00', '01', '02'], ['10', '11', '12']];
+      var element = new Element('items', items, false, doc);
+      before(function() {
+        element.at(1).at(1).remove();
+        element.at(0).insertAfter(element.at(0).at(1), '$new', '99');
+        expect(element.generateObject()).to.deep.equal([
+          ['00', '01', '99', '02'], ['10', '12']
+        ]);
+        element.cancel();
+      });
+      it('reverts the document', function() {
+        expect(element.generateObject()).to.deep.equal(items);
+        expect(element.isModified()).to.equal(false);
+      });
+      it('updates keys correctly', function() {
+        for (let i = 0; i < items.length; i++) {
+          for (let j = 0; j < items[0].length; j++) {
+            const parent = element.at(i);
+            expect(parent.currentKey).to.equal(i);
+            expect(parent.key).to.equal(i);
+            expect(parent.at(j).currentKey).to.equal(j);
+            expect(parent.at(j).key).to.equal(j);
+            expect(parent.at(j).value).to.equal('' + i + j);
+          }
+        }
+      });
     });
   });
 });

--- a/test/element.test.js
+++ b/test/element.test.js
@@ -121,7 +121,7 @@ describe('Element', function() {
       });
     });
 
-    context('when the element is deleted from the middle', function() {
+    context('when elements are deleted from the middle', function() {
       var element = new Element('key', []);
       var child1 = element.insertEnd('', 'test1');
       element.insertEnd('', 'test2');
@@ -135,7 +135,7 @@ describe('Element', function() {
         child3.remove();
       });
 
-      it('returns undefined', function() {
+      it('returns the correct elements', function() {
         expect(element.at(0).currentValue).to.equal('test2');
         expect(element.at(0).currentKey).to.equal(0);
         expect(element.at(1).currentValue).to.equal('test4');

--- a/test/element.test.js
+++ b/test/element.test.js
@@ -103,8 +103,9 @@ describe('Element', function() {
       it('returns the original elements', function() {
         expect(element.at(0).currentValue).to.equal('item0');
         expect(element.at(0).currentKey).to.equal(0);
+        expect(element.at(0).isRemoved()).to.equal(true);
         expect(element.at(1).currentValue).to.equal('item1');
-        expect(element.at(1).currentKey).to.equal(1);
+        expect(element.at(1).currentKey).to.equal(0);
       });
     });
 
@@ -384,31 +385,6 @@ describe('Element', function() {
         expect(element.elements.at(1).isAdded()).to.equal(true);
       });
     });
-
-    context('when the embedded element is an array', function() {
-      var doc = new Document({});
-      var element = new Element('emails', [ 'work@example.com' ], false, doc);
-
-      before(function() {
-        element.insertEnd('', 'home@example.com');
-        element.insertEnd('ignore', 'home@example.com2');
-        element.insertEnd(3, 'home@example.com3');
-      });
-
-      it('adds the new embedded elements', function() {
-        expect(element.elements.at(1).currentKey).to.equal(1);
-        expect(element.elements.at(1).value).to.equal('home@example.com');
-        expect(element.elements.at(2).currentKey).to.equal(2);
-        expect(element.elements.at(2).value).to.equal('home@example.com2');
-        expect(element.elements.at(3).currentKey).to.equal(3);
-        expect(element.elements.at(3).value).to.equal('home@example.com3');
-      });
-
-      it('flags the new element as added', function() {
-        expect(element.elements.at(1).isAdded()).to.equal(true);
-      });
-    });
-
     context('when the embedded element is an array of embedded documents', function() {
       var doc = new Document({});
       var element = new Element('emails', [], false, doc);
@@ -432,6 +408,7 @@ describe('Element', function() {
         expect(element.elements.at(0).elements.at(0).isEdited()).to.equal(false);
       });
     });
+    /* More testing embedded arrays is in 'modifying arrays' */
   });
 
   describe('#insertAfter', function() {
@@ -452,35 +429,7 @@ describe('Element', function() {
         expect(element.elements.at(1).isAdded()).to.equal(true);
       });
     });
-
-    context('when the embedded element is an array', function() {
-      var doc = new Document({});
-      var element = new Element('emails', [ 'item0' ], false, doc);
-
-      before(function() {
-        element.insertAfter(element.at(0), 'key3', 'item3');
-        element.insertAfter(element.at(0), 'ignore', 'item1');
-        element.insertAfter(element.at(1), '', 'item2');
-      });
-
-      it('adds the new embedded elements', function() {
-        expect(element.elements.at(0).currentKey).to.equal(0);
-        expect(element.elements.at(0).value).to.equal('item0');
-        expect(element.elements.at(1).currentKey).to.equal(1);
-        expect(element.elements.at(1).value).to.equal('item1');
-        expect(element.elements.at(2).currentKey).to.equal(2);
-        expect(element.elements.at(2).value).to.equal('item2');
-        expect(element.elements.at(3).currentKey).to.equal(3);
-        expect(element.elements.at(3).value).to.equal('item3');
-      });
-
-      it('flags the new element as added', function() {
-        expect(element.elements.at(0).isAdded()).to.equal(false);
-        expect(element.elements.at(1).isAdded()).to.equal(true);
-        expect(element.elements.at(2).isAdded()).to.equal(true);
-        expect(element.elements.at(3).isAdded()).to.equal(true);
-      });
-    });
+    /* Testing embedded arrays is in 'modifying arrays' */
   });
 
   describe('#isDuplicateKey', function() {
@@ -1584,6 +1533,515 @@ describe('Element', function() {
           expect(element.currentValue).to.equal('test@example.com');
         });
       });
+    });
+  });
+
+  describe('modifying arrays', function() {
+    describe('#insertEnd', function() {
+      var doc = new Document({});
+      var element = new Element('emails', [ 'work@example.com' ], false, doc);
+      const finalArray = [
+        'work@example.com',
+        'home@example.com',
+        'home@example.com2',
+        'home@example.com3'
+      ];
+      before(function() {
+        element.insertEnd('', finalArray[1]);
+        element.insertEnd('ignore', finalArray[2]);
+        element.insertEnd(3, finalArray[3]);
+      });
+      it('adds the new embedded elements', function() {
+        for (let i = 0; i < finalArray.length; i++) {
+          expect(element.elements.at(i).currentKey).to.equal(i);
+          expect(element.elements.at(i).key).to.equal(i);
+          expect(element.elements.at(i).value).to.equal(finalArray[i]);
+        }
+      });
+      it('flags the right elements as added', function() {
+        expect(element.elements.at(1).isAdded()).to.equal(true);
+        expect(element.elements.at(2).isAdded()).to.equal(true);
+        expect(element.elements.at(3).isAdded()).to.equal(true);
+        expect(element.elements.at(0).isModified()).to.equal(false);
+      });
+    });
+
+    describe('#insertAfter', function() {
+      context('inserting into the array', function() {
+        var doc = new Document({});
+        var element = new Element('emails', [ 'item0' ], false, doc);
+        before(function() {
+          element.insertAfter(element.at(0), 'key3', 'item3');
+          element.insertAfter(element.at(0), 'ignore', 'item1');
+          element.insertAfter(element.at(1), '', 'item2');
+        });
+        it('adds the new embedded elements', function() {
+          for (let i = 0; i < 4; i++) {
+            expect(element.elements.at(i).currentKey).to.equal(i);
+            expect(element.elements.at(i).key).to.equal(i);
+            expect(element.elements.at(i).value).to.equal('item' + i);
+          }
+        });
+        it('flags the new element as added', function() {
+          expect(element.elements.at(0).isModified()).to.equal(false);
+          expect(element.elements.at(1).isAdded()).to.equal(true);
+          expect(element.elements.at(2).isAdded()).to.equal(true);
+          expect(element.elements.at(3).isAdded()).to.equal(true);
+        });
+      });
+      context('inserting into the middle of the array', function() {
+        var doc = new Document({});
+        var element = new Element('items', [ 'item0', 'item2', 'item3' ], false, doc);
+
+        before(function() {
+          element.insertAfter(element.at(0), 'key3', 'item1');
+        });
+        it('inserts the element into the list with the correct key', function() {
+          expect(element.at(0).nextElement.currentKey).to.equal(1);
+          expect(element.at(0).nextElement.key).to.equal(1);
+          expect(element.at(0).nextElement.value).to.equal('item1');
+        });
+        it('updates the key and currentKey of subsequent elements', function() {
+          for (let i = 0; i < 4; i ++) {
+            expect(element.at(i).currentKey).to.equal(i);
+            expect(element.at(i).key).to.equal(i);
+            expect(element.at(i).value).to.equal('item' + i);
+          }
+        });
+        it('correctly marks elements as modified', function() {
+          for (let i = 0; i < 4; i ++) {
+            expect(element.at(i).isModified()).to.equal(i === 1);
+          }
+        });
+      });
+      context('inserting into the end of the array', function() {
+        var doc = new Document({});
+        var element = new Element('emails', [ 'item0', 'item1', 'item2' ], false, doc);
+        before(function() {
+          element.insertAfter(element.at(2), 'key3', 'item3');
+        });
+        it('inserts the element into the list with the correct key', function() {
+          expect(element.at(2).nextElement.currentKey).to.equal(3);
+          expect(element.at(2).nextElement.key).to.equal(3);
+          expect(element.at(2).nextElement.value).to.equal('item3');
+        });
+        it('updates the key and currentKey of subsequent elements', function() {
+          for (let i = 0; i < 4; i ++) {
+            expect(element.at(i).currentKey).to.equal(i);
+            expect(element.at(i).key).to.equal(i);
+            expect(element.at(i).value).to.equal('item' + i);
+          }
+        });
+        it('correctly marks elements as modified', function() {
+          for (let i = 0; i < 4; i ++) {
+            expect(element.at(i).isModified()).to.equal(i === 3);
+          }
+        });
+      });
+    });
+
+    describe('#insertPlaceholder', function() {
+      context('into an empty array', function() {
+        var doc = new Document({});
+        var element = new Element('emails', [], false, doc);
+        before(function() {
+          element.insertPlaceholder();
+        });
+        it('array has one element', function() {
+          expect(element.at(0).currentKey).to.equal(0);
+          expect(element.at(0).key).to.equal(0);
+          expect(element.at(0).value).to.equal('');
+          expect(element.elements.size).to.equal(1);
+        });
+        it('element is modified', function() {
+          expect(element.at(0).isModified()).to.equal(true);
+        });
+      });
+      context('into a full array', function() {
+        var doc = new Document({});
+        var element = new Element('emails', ['item0', 'item1', 'item2'], false, doc);
+        before(function() {
+          element.insertPlaceholder();
+        });
+        it('inserts the element into the end', function() {
+          expect(element.at(3).currentKey).to.equal(3);
+          expect(element.at(3).key).to.equal(3);
+          expect(element.at(3).value).to.equal('');
+        });
+        it('keeps the other elements the same', function() {
+          expect(element.elements.size).to.equal(4);
+          for (let i = 0; i < 3; i ++) {
+            expect(element.at(i).currentKey).to.equal(i);
+            expect(element.at(i).key).to.equal(i);
+            expect(element.at(i).value).to.equal('item' + i);
+          }
+        });
+        it('element is modified', function() {
+          for (let i = 0; i < 4; i ++) {
+            expect(element.at(i).isModified()).to.equal(i === 3);
+          }
+        });
+      });
+    });
+
+    describe('#remove', function() {
+      context('element to be removed is top-level', function() {
+        context('and is added', function() {
+          var doc = new Document({});
+          const items = [ 'item0', 'item2' ];
+          var element = new Element('items', items, false, doc);
+
+          before(function() {
+            element.insertAfter(element.at(0), 'key3', 'item1');
+            expect(element.generateObject()).to.deep.equal(
+              ['item0', 'item1', 'item2']
+            );
+            element.at(1).remove();
+          });
+          it('deletes the element', function() {
+            expect(element.generateObject()).to.deep.equal(items);
+            expect(element.isModified()).to.equal(false);
+          });
+          it('updates keys correctly', function() {
+            expect(element.at(0).currentKey).to.equal(0);
+            expect(element.at(0).key).to.equal(0);
+            expect(element.at(0).value).to.equal('item0');
+            expect(element.at(1).currentKey).to.equal(1);
+            expect(element.at(1).key).to.equal(1);
+            expect(element.at(1).value).to.equal('item2');
+          });
+        });
+        context('and is not added', function() {
+          var doc = new Document({});
+          const items = [ 'item0', 'item2' ];
+          var element = new Element('items', ['item0', 'item1', 'item2'], false, doc);
+
+          before(function() {
+            element.at(1).remove();
+          });
+          it('deletes the element', function() {
+            expect(element.generateObject()).to.deep.equal(items);
+            expect(element.isModified()).to.equal(true);
+          });
+          it('updates keys correctly', function() {
+            expect(element.at(0).currentKey).to.equal(0);
+            expect(element.at(0).key).to.equal(0);
+            expect(element.at(0).value).to.equal('item0');
+            expect(element.at(2).currentKey).to.equal(1);
+            expect(element.at(2).key).to.equal(1);
+            expect(element.at(2).value).to.equal('item2');
+          });
+          it('sets flags correctly', function() {
+            expect(element.at(0).isModified()).to.equal(false);
+            expect(element.at(1).isRemoved()).to.equal(true);
+            expect(element.at(2).isModified()).to.equal(false);
+          });
+        });
+      });
+      context('element to be removed is nested', function() {
+        context('and is added', function() {
+          var doc = new Document({});
+          const items = [['00', '01', '02'], ['10', '11', '12']];
+          var element = new Element('items', items, false, doc);
+          before(function() {
+            element.at(0).insertAfter(element.at(0).at(1), '$new', '99');
+            expect(element.generateObject()).to.deep.equal([
+              ['00', '01', '99', '02'], ['10', '11', '12']
+            ]);
+            element.at(0).at(2).remove();
+          });
+          it('reverts the document', function() {
+            expect(element.generateObject()).to.deep.equal(items);
+            expect(element.isModified()).to.equal(false);
+          });
+          it('updates keys correctly', function() {
+            for (let i = 0; i < items.length; i++) {
+              for (let j = 0; j < items[0].length; j++) {
+                const parent = element.at(i);
+                expect(parent.currentKey).to.equal(i);
+                expect(parent.key).to.equal(i);
+                expect(parent.at(j).currentKey).to.equal(j);
+                expect(parent.at(j).key).to.equal(j);
+                expect(parent.at(j).value).to.equal('' + i + j);
+              }
+            }
+          });
+        });
+        context('and is not added', function() {
+          var doc = new Document({});
+          const items = [['00', '01', '99', '02'], ['10', '11', '12']];
+          var element = new Element('items', items, false, doc);
+          before(function() {
+            element.at(0).at(2).remove();
+          });
+          it('reverts the document', function() {
+            expect(element.generateObject()).to.deep.equal([
+                ['00', '01', '02'], ['10', '11', '12']
+            ]);
+            expect(element.isModified()).to.equal(true);
+          });
+          it('leave the top level be', function() {
+            expect(element.at(0).currentKey).to.equal(0);
+            expect(element.at(0).key).to.equal(0);
+            expect(element.at(0).isModified()).to.equal(true);
+            expect(element.at(1).currentKey).to.equal(1);
+            expect(element.at(1).key).to.equal(1);
+            expect(element.at(1).isModified()).to.equal(false);
+          });
+          it('updates keys correctly', function() {
+            const parent = element.at(0);
+            expect(parent.at(0).currentKey).to.equal(0);
+            expect(parent.at(0).key).to.equal(0);
+            expect(parent.at(0).value).to.equal('00');
+            expect(parent.at(1).currentKey).to.equal(1);
+            expect(parent.at(1).key).to.equal(1);
+            expect(parent.at(1).value).to.equal('01');
+            expect(parent.at(3).currentKey).to.equal(2);
+            expect(parent.at(3).key).to.equal(2);
+            expect(parent.at(3).value).to.equal('02');
+          });
+          it('updates flags correctly', function() {
+            const parent = element.at(0);
+            expect(parent.at(0).isModified()).to.equal(false);
+            expect(parent.at(1).isModified()).to.equal(false);
+            expect(parent.at(2).isRemoved()).to.equal(true);
+            expect(parent.at(3).isModified()).to.equal(false);
+          });
+        });
+      });
+    });
+
+    describe('#revert', function() {
+      context('element to be removed is top-level', function() {
+        context('and is added', function() {
+          var doc = new Document({});
+          const items = [ 'item0', 'item1', 'item2' ];
+          var element = new Element('items', [ 'item0', 'item1', 'item2' ], false, doc);
+
+          before(function() {
+            element.insertAfter(element.at(0), 'key3', 'item9');
+            expect(element.generateObject()).to.deep.equal(
+              ['item0', 'item9', 'item1', 'item2']
+            );
+            element.revert();
+          });
+          it('reverts the document', function() {
+            expect(element.generateObject()).to.deep.equal(items);
+            expect(element.isModified()).to.equal(false);
+          });
+          it('updates keys correctly', function() {
+            for (let i = 0; i < items.length; i++) {
+              expect(element.at(i).currentKey).to.equal(i);
+              expect(element.at(i).key).to.equal(i);
+              expect(element.at(i).value).to.equal('item' + i);
+            }
+          });
+        });
+        context('and is removed', function() {
+          var doc = new Document({});
+          const items = [ 'item0', 'item1', 'item2', 'item3' ];
+          var element = new Element('items', items, false, doc);
+
+          before(function() {
+            element.at(1).remove();
+            expect(element.generateObject()).to.deep.equal(
+              ['item0', 'item2', 'item3']
+            );
+            element.revert();
+          });
+          it('reverts the document', function() {
+            expect(element.generateObject()).to.deep.equal(items);
+            expect(element.isModified()).to.equal(false);
+          });
+          it('updates keys correctly', function() {
+            for (let i = 0; i < items.length; i++) {
+              expect(element.at(i).currentKey).to.equal(i);
+              expect(element.at(i).key).to.equal(i);
+              expect(element.at(i).value).to.equal('item' + i);
+            }
+          });
+        });
+      });
+      context('element to be removed is nested', function() {
+        context('revert on top-level element', function() {
+          context('and is added', function() {
+            var doc = new Document({});
+            const items = [['00', '01', '02'], ['10', '11', '12']];
+            var element = new Element('items', items, false, doc);
+            before(function() {
+              element.at(0).insertAfter(element.at(0).at(1), '$new', '99');
+              expect(element.generateObject()).to.deep.equal([
+                ['00', '01', '99', '02'], ['10', '11', '12']
+              ]);
+              element.revert();
+            });
+            it('reverts the document', function() {
+              expect(element.generateObject()).to.deep.equal(items);
+              expect(element.isModified()).to.equal(false);
+            });
+            it('updates keys correctly', function() {
+              for (let i = 0; i < items.length; i++) {
+                for (let j = 0; j < items[0].length; j++) {
+                  const parent = element.at(i);
+                  expect(parent.currentKey).to.equal(i);
+                  expect(parent.key).to.equal(i);
+                  expect(parent.at(j).currentKey).to.equal(j);
+                  expect(parent.at(j).key).to.equal(j);
+                  expect(parent.at(j).value).to.equal('' + i + j);
+                }
+              }
+            });
+          });
+          context('and is removed', function() {
+            var doc = new Document({});
+            const items = [['00', '01', '02'], ['10', '11', '12']];
+            var element = new Element('items', items, false, doc);
+            before(function() {
+              element.at(0).at(1).remove();
+              expect(element.generateObject()).to.deep.equal([
+                ['00', '02'], ['10', '11', '12']
+              ]);
+              element.revert();
+            });
+            it('reverts the document', function() {
+              expect(element.generateObject()).to.deep.equal(items);
+              expect(element.isModified()).to.equal(false);
+            });
+            it('updates keys correctly', function() {
+              for (let i = 0; i < items.length; i++) {
+                for (let j = 0; j < items[0].length; j++) {
+                  const parent = element.at(i);
+                  expect(parent.currentKey).to.equal(i);
+                  expect(parent.key).to.equal(i);
+                  expect(parent.at(j).currentKey).to.equal(j);
+                  expect(parent.at(j).key).to.equal(j);
+                  expect(parent.at(j).value).to.equal('' + i + j);
+                }
+              }
+            });
+          });
+        });
+        context('revert on nested element', function() {
+          context('and is added', function() {
+            var doc = new Document({});
+            const items = [['00', '01', '02'], ['10', '11', '12']];
+            var element = new Element('items', items, false, doc);
+            before(function() {
+              element.at(0).insertAfter(element.at(0).at(1), '$new', '99');
+              expect(element.generateObject()).to.deep.equal([
+                ['00', '01', '99', '02'], ['10', '11', '12']
+              ]);
+              element.at(0).revert();
+            });
+            it('reverts the document', function() {
+              expect(element.generateObject()).to.deep.equal(items);
+              expect(element.isModified()).to.equal(false);
+            });
+            it('updates keys correctly', function() {
+              for (let i = 0; i < items.length; i++) {
+                for (let j = 0; j < items[0].length; j++) {
+                  const parent = element.at(i);
+                  expect(parent.currentKey).to.equal(i);
+                  expect(parent.key).to.equal(i);
+                  expect(parent.at(j).currentKey).to.equal(j);
+                  expect(parent.at(j).key).to.equal(j);
+                  expect(parent.at(j).value).to.equal('' + i + j);
+                }
+              }
+            });
+          });
+          context('and is removed', function() {
+            var doc = new Document({});
+            const items = [['00', '01', '02'], ['10', '11', '12']];
+            var element = new Element('items', items, false, doc);
+            before(function() {
+              element.at(0).at(1).remove();
+              expect(element.generateObject()).to.deep.equal([
+                ['00', '02'], ['10', '11', '12']
+              ]);
+              element.at(0).revert();
+            });
+            it('reverts the document', function() {
+              expect(element.generateObject()).to.deep.equal(items);
+              expect(element.isModified()).to.equal(false);
+            });
+            it('updates keys correctly', function() {
+              for (let i = 0; i < items.length; i++) {
+                for (let j = 0; j < items[0].length; j++) {
+                  const parent = element.at(i);
+                  expect(parent.currentKey).to.equal(i);
+                  expect(parent.key).to.equal(i);
+                  expect(parent.at(j).currentKey).to.equal(j);
+                  expect(parent.at(j).key).to.equal(j);
+                  expect(parent.at(j).value).to.equal('' + i + j);
+                }
+              }
+            });
+          });
+        });
+        context('revert on most nested element', function() {
+          context('and is added', function() {
+            var doc = new Document({});
+            const items = [['00', '01', '02'], ['10', '11', '12']];
+            var element = new Element('items', items, false, doc);
+            before(function() {
+              element.at(0).insertAfter(element.at(0).at(1), '$new', '99');
+              expect(element.generateObject()).to.deep.equal([
+                ['00', '01', '99', '02'], ['10', '11', '12']
+              ]);
+              element.at(0).at(2).revert();
+            });
+            it('reverts the document', function() {
+              expect(element.generateObject()).to.deep.equal(items);
+              expect(element.isModified()).to.equal(false);
+            });
+            it('updates keys correctly', function() {
+              for (let i = 0; i < items.length; i++) {
+                for (let j = 0; j < items[0].length; j++) {
+                  const parent = element.at(i);
+                  expect(parent.currentKey).to.equal(i);
+                  expect(parent.key).to.equal(i);
+                  expect(parent.at(j).currentKey).to.equal(j);
+                  expect(parent.at(j).key).to.equal(j);
+                  expect(parent.at(j).value).to.equal('' + i + j);
+                }
+              }
+            });
+          });
+          context('and is removed', function() {
+            var doc = new Document({});
+            const items = [['00', '01', '02'], ['10', '11', '12']];
+            var element = new Element('items', items, false, doc);
+            before(function() {
+              element.at(0).at(1).remove();
+              expect(element.generateObject()).to.deep.equal([
+                ['00', '02'], ['10', '11', '12']
+              ]);
+              element.at(0).at(1).revert();
+            });
+            it('reverts the document', function() {
+              expect(element.generateObject()).to.deep.equal(items);
+              expect(element.isModified()).to.equal(false);
+            });
+            it('updates keys correctly', function() {
+              for (let i = 0; i < items.length; i++) {
+                for (let j = 0; j < items[0].length; j++) {
+                  const parent = element.at(i);
+                  expect(parent.currentKey).to.equal(i);
+                  expect(parent.key).to.equal(i);
+                  expect(parent.at(j).currentKey).to.equal(j);
+                  expect(parent.at(j).key).to.equal(j);
+                  expect(parent.at(j).value).to.equal('' + i + j);
+                }
+              }
+            });
+          });
+        });
+      });
+    });
+
+    describe('#cancel', function() {
+
     });
   });
 });

--- a/test/shared-examples.js
+++ b/test/shared-examples.js
@@ -39,7 +39,7 @@ class SharedExamples {
     });
 
     it('adds the new embedded element', function() {
-      expect(this.doc.elements.at(0).elements.at(0).key).to.equal('');
+      expect(this.doc.elements.at(0).elements.at(0).key).to.equal(0);
     });
 
     it('sets the new embedded element value', function() {
@@ -60,7 +60,7 @@ class SharedExamples {
     });
 
     it('adds the new embedded element', function() {
-      expect(this.doc.elements.at(0).elements.at(0).key).to.equal('');
+      expect(this.doc.elements.at(0).elements.at(0).key).to.equal(0);
     });
 
     it('sets the new embedded element document key', function() {


### PR DESCRIPTION
Previously, HadronElements that were elements of an array would have an empty string as their `key` or `currentKey` fields. This PR makes it so that those elements now keep track of their index, as an integer, in the `key` or `currentKey` fields. I also made docstring changes so that the linter wouldn't have any warnings. Everything else should work exactly the same.

This change is needed to allow for nested arrays within the compass-crud table view, since array elements and object elements need to behave the same.

I tried not to make any backwards changes, but I did change the `at` function so it now returns undefined if the index was out of scope, instead of null. This is so `get` and `at` have the same behavior.

@durran If you could give this a solid look, I want to make sure I haven't broken anything. It's a PR against '2205-base' instead of master because some of these changes have already been added to master because they were required to build the demo version of compass-community to include table view. This way the whole set of changes is included in the diff. If it looks good to you I'll handle the merge/rebasing.

Thanks!