### PR TITLE
COMPASS-2333 - next() does not remove empty fields

### DIFF
--- a/lib/element.js
+++ b/lib/element.js
@@ -615,13 +615,7 @@ class Element extends EventEmitter {
    * Add a new element to the parent.
    */
   _next() {
-    if (this._isElementEmpty(this.nextElement)) {
-      this.parent.elements.remove(this.nextElement);
-      this.parent.emit(Events.Removed);
-    } else if (this._isElementEmpty(this)) {
-      this.parent.elements.remove(this);
-      this.parent.emit(Events.Removed);
-    } else {
+    if (!this._isElementEmpty(this.nextElement) && !this._isElementEmpty(this)) {
       this.parent.insertAfter(this, '', '');
     }
   }

--- a/test/element.test.js
+++ b/test/element.test.js
@@ -575,7 +575,7 @@ describe('Element', function() {
           });
 
           it('removes the empty element', function() {
-            expect(doc.elements.size).to.equal(1);
+            expect(doc.elements.size).to.equal(2);
           });
         });
       });
@@ -590,8 +590,8 @@ describe('Element', function() {
             element.next();
           });
 
-          it('removes the empty element', function() {
-            expect(doc.elements.size).to.equal(1);
+          it('ignores the empty element', function() {
+            expect(doc.elements.size).to.equal(2);
           });
         });
 


### PR DESCRIPTION
@durran I wasn't sure about this fix because it looks like there were tests explicitly testing for the old behavior. I played around with these changes in compass-crud and it behaves the way I would expect:

![placeholder](https://user-images.githubusercontent.com/1045019/33557637-12ad2d34-d908-11e7-956d-f048062acefc.gif)

However the tests were testing that calling next() when there was an empty element would remove that element instead of leaving it be. We could fix it by removing the element, then adding a new one, but I don't see a reason why we'd want to do that instead of just leaving the original element.